### PR TITLE
Add query to Discovery when it is configured.

### DIFF
--- a/run.py
+++ b/run.py
@@ -7,6 +7,7 @@ from cloudant.client import Cloudant
 from dotenv import load_dotenv
 from slackclient import SlackClient
 from watson_developer_cloud import ConversationV1
+from watson_developer_cloud import DiscoveryV1
 
 from watsononlinestore.watson_online_store import WatsonOnlineStore
 from database.cloudant_online_store import CloudantOnlineStore
@@ -33,9 +34,29 @@ if __name__ == "__main__":
         os.environ.get("CLOUDANT_DB_NAME")
     )
 
+  #
+  # Init Watson Discovery only if all the env vars are set.
+  #
+  discovery_username = os.environ.get('DISCOVERY_USERNAME')
+  discovery_password = os.environ.get('DISCOVERY_PASSWORD')
+  discovery_environment_id = os.environ.get('DISCOVERY_ENVIRONMENT_ID')
+  discovery_collection_id = os.environ.get('DISCOVERY_COLLECTION_ID')
+
+  discovery_client = None
+  if all((discovery_username,
+          discovery_password,
+          discovery_environment_id,
+          discovery_collection_id)):
+
+      discovery_client = DiscoveryV1(
+          version='2016-11-07',
+          username=discovery_username,
+          password=discovery_password)
+
   watsononlinestore = WatsonOnlineStore(bot_id,
                                   slack_client,
                                   conversation_client,
+                                  discovery_client,
                                   cloudant_online_store)
 
   watsononlinestore.run()

--- a/tests/test_watson_online_store.py
+++ b/tests/test_watson_online_store.py
@@ -9,11 +9,15 @@ def test_0():
         'context': {'send_no_input': 'no'},
         'output': {'text': 'fake output text'},
     }
+    discovery_client = None
     slack_client = mock.Mock()
     cloudant_store = mock.Mock()
 
-    wosbot = watson_online_store.WatsonOnlineStore('botid', slack_client,
-                                                    conv_client, cloudant_store)
+    wosbot = watson_online_store.WatsonOnlineStore('botid',
+                                                   slack_client,
+                                                   conv_client,
+                                                   discovery_client,
+                                                   cloudant_store)
     wosbot.handle_message("this is a test", "this is a channel")
 
     conv_client.assert_has_calls([

--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -1,5 +1,6 @@
 import os
 import time
+from pprint import pprint
 
 DEBUG=True
 
@@ -18,16 +19,22 @@ class OnlineStoreCustomer:
  
 class WatsonOnlineStore:
     def __init__(self, bot_id, slack_client,
-                 conversation_client, cloudant_online_store):
+                 conversation_client, discovery_client,
+                 cloudant_online_store):
         self.bot_id = bot_id
 
         self.slack_client = slack_client
         self.conversation_client = conversation_client
+        self.discovery_client = discovery_client
         self.cloudant_online_store = cloudant_online_store
 
         self.at_bot = "<@" + bot_id + ">"
         self.delay = 0.5  # second
         self.workspace_id = os.environ.get("WORKSPACE_ID")
+        self.discovery_environment_id = os.environ.get(
+            'DISCOVERY_ENVIRONMENT_ID')
+        self.discovery_collection_id = os.environ.get(
+            'DISCOVERY_COLLECTION_ID')
 
         self.context = {}
         self.context['email'] = None
@@ -132,6 +139,61 @@ class WatsonOnlineStore:
             context=self.context)
         return response
 
+    @staticmethod
+    def format_discovery_response(response):
+        """Try to limit the volumes of response to just enough."""
+        # Using top N hard-coded here, for now.
+        top_n = 5
+
+        if not ('results' in response and response['results']):
+            return "No results from Discovery."
+
+        results = response['results']
+
+        output = ["Top results found for your query:"]
+        for i in range(top_n):
+            result = results[i]
+            if 'blekko' not in result:
+                output.append("todo - missing expected result key")
+            else:
+                blekko = result['blekko']
+                if 'snippet' in blekko:
+                    snippet = blekko['snippet']
+                    output.append('\n'.join(snippet))
+                elif 'clean_title' in blekko:
+                    # Using elif because snippet usually includes a title.
+                    clean_title = blekko['clean_title']
+                    output.append('\n'.join(clean_title))
+
+                if 'url' in blekko:
+                    url = blekko['url']
+                    output.append(url)
+
+                if 'twitter' in blekko and 'image' in blekko['twitter']:
+                    twitter_image = blekko['twitter']['image']
+                    output.append(twitter_image)
+
+        return '\n'.join(output)
+
+    def get_discovery_response(self, input_text):
+
+        discovery_response = self.discovery_client.query(
+            environment_id=self.discovery_environment_id,
+            collection_id=self.discovery_collection_id,
+            query_options={'query': input_text}
+        )
+        if DEBUG:
+            # This dumps a ton of results for us to peruse:
+            pprint(discovery_response)
+
+        formatted_response = self.format_discovery_response(discovery_response)
+
+        if DEBUG:
+            # This dumps a ton of results for us to peruse:
+            pprint(formatted_response)
+
+        return formatted_response
+
     def handle_message(self, message, channel):
         """ Handler for messages.
             param: message from UI (slackbot)
@@ -142,7 +204,6 @@ class WatsonOnlineStore:
         """
 
         watson_response = self.get_watson_response(message)
-
         if DEBUG:
             print("watson_response:\n{}\n".format(watson_response))
         self.context = watson_response['context']
@@ -150,6 +211,12 @@ class WatsonOnlineStore:
         response = ''
         for text in watson_response['output']['text']:
             response += text + "\n"
+
+        # Ask Discovery for a response if we have a Discovery client
+        if self.discovery_client:
+            discovery_response = self.get_discovery_response(message)
+            if discovery_response:
+                response += discovery_response + "\n"
 
         self.post_to_slack(response, channel)
 


### PR DESCRIPTION
If all the necessary env vars are set, Discovery
is added.

For now, it is always called when avilable and the
top selected result snippets (etc) are appended to
the response.

The full results are logged for dev/test.