### PR TITLE
For direct message, don't require the at-bot-id. Just chat.

### DIFF
--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -72,17 +72,23 @@ class WatsonOnlineStore:
 
         return new_dict
 
-    def parse_slack_output(self, slack_rtm_output):
-        output_list = slack_rtm_output
+    def parse_slack_output(self, output_list):
         if output_list and len(output_list) > 0:
             for output in output_list:
-                if output and 'text' in output and \
-                    'user_profile' not in output and \
-                        self.at_bot in output['text']:
-                    return (output['text'].split(
-                        self.at_bot)[1].strip().lower(),
-                         output['channel'],
-                         output['user'])
+                if output and 'text' in output and (
+                            'user_profile' not in output):
+                    if self.at_bot in output['text']:
+                        return (
+                            ''.join(output['text'].split(self.at_bot
+                                                         )).strip().lower(),
+                            output['channel'],
+                            output['user'])
+                    elif (output['channel'].startswith('D')
+                          and output['user'] != self.bot_id):
+                        # Direct message!
+                        return (output['text'].strip().lower(),
+                                output['channel'],
+                                output['user'])
         return None, None, None
 
     def post_to_slack(self, response, channel):


### PR DESCRIPTION
First check for at-botid so that we can remove that from the text.
Also fix so that the at-botid doesn't have to be first. It can
be tacked on at the end or wherever to get the bot's attention.
If there are multiple mentions remove them all.
There might be a little extra whitespace, but no harm.

If there is not an at-botid, then check to see if it is
a direct message. A channel that starts with a D is a
direct message. For direct message you don't need to
type that at-botid.