### PR TITLE
Fix KeyError. Add check for 'user'.

### DIFF
--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -75,7 +75,7 @@ class WatsonOnlineStore:
     def parse_slack_output(self, output_list):
         if output_list and len(output_list) > 0:
             for output in output_list:
-                if output and 'text' in output and (
+                if output and 'text' in output and 'user' in output and (
                             'user_profile' not in output):
                     if self.at_bot in output['text']:
                         return (


### PR DESCRIPTION
Hit a KeyError when slackbot decided to send me a message
about suppressing unfurling of images. Slackbot's message
had a 'username', but not a 'user' so it was a KeyError.
Just filter those out.