### PR TITLE
fixed create disco env call

### DIFF
--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -237,7 +237,7 @@ class WatsonOnlineStore:
                     created = discovery_client.create_environment(
                         name,
                         "Discovery environment created by "
-                        "watson-online-store.", 0)
+                        "watson-online-store.")
                     environment_id = created['environment_id']
                     LOG.debug("Created DISCOVERY_ENVIRONMENT_ID=%(id)s with "
                               "name=%(name)s" %


### PR DESCRIPTION
Removed param from call - left in inadvertently when testing. 
Note that this call still fails, but now we are calling it correctly.