### PR TITLE
use the deployment tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,27 @@ SLACK_BOT_USER=wos
 # License
 
 [Apache 2.0](LICENSE)
+
+# Privacy Notice
+
+If using the Deploy to Bluemix button some metrics are tracked, the following
+information is sent to a [Deployment Tracker](https://github.com/IBM-Bluemix/cf-deployment-tracker-service) service
+on each deployment:
+
+* Python package version
+* Python repository URL
+* Application Name (application_name)
+* Application GUID (application_id)
+* Application instance index number (instance_index)
+* Space ID (space_id)
+* Application Version (application_version)
+* Application URIs (application_uris)
+* Labels of bound services
+* Number of instances for each bound service and associated plan information
+* This data is collected from the setup.py file in the sample application and the VCAP_APPLICATION and VCAP_SERVICES environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+
+## Disabling Deployment Tracking
+
+To disable tracking, simply remove ``cf_deployment_tracker.track()`` from the
+``run.py`` file in the top level directory.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cf-deployment-tracker==1.0.4
 cloudant==2.4.0
 python-dotenv==0.5.1
 slackclient==1.0.5

--- a/run.py
+++ b/run.py
@@ -15,6 +15,7 @@
 import json
 import os
 
+import cf_deployment_tracker
 from cloudant.client import Cloudant
 from dotenv import load_dotenv
 from slackclient import SlackClient
@@ -178,6 +179,8 @@ class WatsonEnv:
 
 
 if __name__ == "__main__":
+    cf_deployment_tracker.track()
+
     watsononlinestore = WatsonEnv.get_watson_online_store()
 
     watsononlinestore.run()


### PR DESCRIPTION
- add cf-deployment-tracker as a requirement
- add a line to track the deployments
- include privacy note and how to disable tracking

another patch will update the badges once the app
is registered with the tracker.