### PR TITLE
Fix for Slack with missing name.

### DIFF
--- a/watsononlinestore/tests/unit/test_watson_online_store.py
+++ b/watsononlinestore/tests/unit/test_watson_online_store.py
@@ -132,6 +132,23 @@ class WOSTestCase(unittest.TestCase):
         self.cloudant_store.find_customer.assert_called_once_with(
             test_email_addr)
 
+    def test_init_customer_slack_no_name(self):
+        test_email_addr = 'e@mail'
+        self.slack_client.api_call = mock.Mock(
+            return_value={'user': {'profile': {'email': test_email_addr,
+                                               'first_name': '',
+                                               'last_name': '',
+                                               }}})
+        self.cloudant_store.find_customer = mock.Mock(return_value={})
+        user = "testuser"
+
+        self.wos.init_customer(user)
+
+        self.slack_client.api_call.assert_called_once_with(
+            'users.info', user=user)
+        self.cloudant_store.find_customer.assert_called_once_with(
+            test_email_addr)
+
     @ddt.data(
         ([{'text': '<@UBOTID> suFFix', 'channel': 'C', 'user': 'U'}],
          ('suffix', 'C', 'U')),

--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -410,8 +410,14 @@ class WatsonOnlineStore:
         """
 
         email_addr = user_json['user']['profile']['email']
-        first = user_json['user']['profile']['first_name']
-        last = user_json['user']['profile']['last_name']
+        try:
+            first = user_json['user']['profile']['first_name']
+        except KeyError:
+            first = email_addr
+        try:
+            last = user_json['user']['profile']['last_name']
+        except KeyError:
+            last = email_addr
         self.customer = OnlineStoreCustomer(email=email_addr,
                                             first_name=first,
                                             last_name=last,


### PR DESCRIPTION
Issue:
https://github.com/IBM/watson-online-store/issues/79

A slack user may not have a first_name or last_name.
This fix uses the email addr as a fall back if either name is missing.