### PR TITLE
watson discovery changes

### DIFF
--- a/run.py
+++ b/run.py
@@ -153,7 +153,7 @@ class WatsonEnv:
 
         # Instantiate Watson Discovery client.
         discovery_client = DiscoveryV1(
-            version='2016-11-07',
+            version='2017-07-19',
             username=discovery_username,
             password=discovery_password)
 

--- a/watsononlinestore/tests/unit/test_watson_online_store.py
+++ b/watsononlinestore/tests/unit/test_watson_online_store.py
@@ -273,8 +273,7 @@ class WOSTestCase(unittest.TestCase):
         expected_environment_id = 'testing with a env ID'
         expected_collection_id = 'testing with a coll ID'
         test_environ = {'DISCOVERY_ENVIRONMENT_ID': expected_environment_id,
-                        self.fake_data_source + '_DISCO_COLLECTION_ID':
-                            expected_collection_id}
+                        'DISCOVERY_COLLECTION_ID': expected_collection_id}
 
         self.discovery_client.get_environment = mock.Mock(return_value={
             'environment_id': expected_environment_id})

--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -271,7 +271,7 @@ class WatsonOnlineStore:
                                     "Error: %s" % repr(e))
 
         # Determine if collection exists.
-        collection_id = environ.get(data_source + '_DISCO_COLLECTION_ID')
+        collection_id = environ.get('DISCOVERY_COLLECTION_ID')
         if collection_id:
             try:
                 LOG.debug("Using DISCOVERY_COLLECTION_ID=%s" % collection_id)


### PR DESCRIPTION
- Updated to newest version of watson discovery
- Now uses correct env key for collection id. Previously, we would always create a new collection, even if it already existed and was specified in the .env file.