### PR TITLE
Add info for changing logging from Debug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ should appear:
 
 ``Watson Online Store bot is connected and running!``
 
+* Large amount of Red Logging info appears.
+
+This is expected. The color for logging in Bluemix will be red, regardless of the
+nature of the message. The log levels are set to "Debug" to assist the developer
+in seeing how the code is executing. This can be changed to logging.WARN or 
+logging.ERROR in the [python code](https://github.com/IBM/watson-online-store/blob/master/watsononlinestore/watson_online_store.py#L22).
+
 # License
 
 [Apache 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ should appear:
 
 This is expected. The color for logging in Bluemix will be red, regardless of the
 nature of the message. The log levels are set to "Debug" to assist the developer
-in seeing how the code is executing. This can be changed to logging.WARN or 
-logging.ERROR in the [python code](https://github.com/IBM/watson-online-store/blob/master/watsononlinestore/watson_online_store.py#L22).
+in seeing how the code is executing. This can be changed to ``logging.WARN`` or 
+``logging.ERROR`` in the [python code](https://github.com/IBM/watson-online-store/blob/master/watsononlinestore/watson_online_store.py#L22).
 
 # License
 


### PR DESCRIPTION
Add info to the troubleshooting guide that explains why the logging
output from Bluemix is red (it is always red), so that it is not
confused with an error.
Explain that log level is set to DEBUG, but can be changed, and
provide a link to the code where it can be changed to WARN or ERROR.

Closes: #86