### PR TITLE
Filter for 'didn't unfurl' messages in slack output.

### DIFF
--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -866,7 +866,7 @@ class WatsonOnlineStore:
                 if message:
                     LOG.debug("message:\n %s\n channel:\n %s\n" %
                               (message, channel))
-                if message and channel:
+                if message and channel and 'unfurl' not in message:
                     sender = SlackSender(self.slack_client, channel)
                     get_input = self.handle_message(message, sender)
                     while not get_input:


### PR DESCRIPTION
If Slack sees the same URL frequently, it won't unfurl them.
When using Direct Messaging to the bot, this will cause the
"Didn't unfurl..." message to be sent to Watson conversation,
and will cause a cascade of errors.

Closes: #107