### PR TITLE
Change watson_online_store to watson-online-store for DB

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -9,7 +9,7 @@ WORKSPACE_ID=<add_conversation_workspace>
 # Cloudant DB
 CLOUDANT_USERNAME=<add_cloudant_username>
 CLOUDANT_PASSWORD=<add_cloudant_password>
-CLOUDANT_DB_NAME=watson_online_store
+CLOUDANT_DB_NAME=watson-online-store
 CLOUDANT_URL=<add_cloudant_url>
 
 # Watson Discovery


### PR DESCRIPTION
In env.sample we have:
CLOUDANT_DB_NAME=watson_online_store
but the name of the db is:
watson-online-store
in the manifest.yaml for Deploy to IBM cloud

Closes: #139