### PR TITLE
removed encode which creates bytes string

### DIFF
--- a/watsononlinestore/watson_online_store.py
+++ b/watsononlinestore/watson_online_store.py
@@ -728,7 +728,7 @@ class WatsonOnlineStore:
         """
         cust = self.customer.email
         shopping_list = self.cloudant_online_store.list_shopping_cart(cust)
-        formatted_out = "\n".join("{}) {}".format(i + 1, item.encode('utf-8'))
+        formatted_out = "\n".join("{}) {}".format(i + 1, item)
                                   for i, item in enumerate(shopping_list))
         self.context['shopping_cart'] = formatted_out
 


### PR DESCRIPTION
The `item.encode(...)` call was unnecessarily encoding items and converting them into bytes.

Closes: #142