### PR TITLE
Let client inits use SDK, URL, etc...

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -5,6 +5,7 @@
 CONVERSATION_USERNAME=<add_conversation_username>
 CONVERSATION_PASSWORD=<add_conversation_password>
 WORKSPACE_ID=<add_conversation_workspace>
+CONVERSATION_URL=<add_conversation_url>
 
 # Cloudant DB
 CLOUDANT_USERNAME=<add_cloudant_username>

--- a/python-flask-server/server.py
+++ b/python-flask-server/server.py
@@ -18,7 +18,7 @@ from flask_socketio import SocketIO, emit
 
 sys.path.append(os.getcwd())
 sys.path.append(os.path.join(os.getcwd(), '..'))
-from run import WatsonEnv, MISSING_ENV_VARS  # noqa
+from run import WatsonEnv  # noqa
 
 # Async mode allows us to run the Slack chatbot along with the web UI.
 async_mode = "threading"
@@ -88,7 +88,8 @@ def do_message(message):
 
     if not watson:
         # Report incomplete setup.
-        sender.send_message(MISSING_ENV_VARS)
+        sender.send_message(
+            "Sorry. The Watson Online Store is closed (failed to initialize).")
 
     elif message['data']:
         # Send message to WatsonOnlineStore and start a conversation loop.

--- a/run.py
+++ b/run.py
@@ -80,7 +80,8 @@ class WatsonEnv:
         cloudant_username = os.environ.get("CLOUDANT_USERNAME")
         cloudant_password = os.environ.get("CLOUDANT_PASSWORD")
         cloudant_url = os.environ.get("CLOUDANT_URL")
-        cloudant_db_name = os.environ.get("CLOUDANT_DB_NAME") or 'watson_online_store'
+        cloudant_db_name = os.environ.get(
+            "CLOUDANT_DB_NAME") or 'watson_online_store'
         discovery_username = os.environ.get('DISCOVERY_USERNAME')
         discovery_password = os.environ.get('DISCOVERY_PASSWORD')
         discovery_url = os.environ.get('DISCOVERY_URL')

--- a/watsononlinestore/database/cloudant_online_store.py
+++ b/watsononlinestore/database/cloudant_online_store.py
@@ -22,7 +22,7 @@ class CloudantOnlineStore(object):
     def __init__(self, client, db_name):
         """Creates a new instance of CloudantOnlineStore.
 
-        :param Cloudant client: instance of cloudant client to connect to
+        :param Object client: instance of Cloudant client to connect to
         :param str db_name: name of the database to use
         """
         self.client = client


### PR DESCRIPTION
Let watson-developer-cloud SDK do the VCAP work.
Pass in URL when needed (use SDK default otherwise).
Let client inits throw errors instead of current checks
(the errors are as good or better).
Make Cloudant client init code behave like the SDK clients.

Closes #77