### PR TITLE
Pin watson-developer-cloud version to 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ Flask>=0.12
 Flask_SocketIO>=2.8.5
 python-dotenv==0.5.1
 slackclient==1.0.5
-watson-developer-cloud>=2.0.0
+watson-developer-cloud==2.0.0
 websocket-client==0.35.0


### PR DESCRIPTION
To prevent accidentally pulling in breaking changes,
pin the version.