### PR TITLE
Pin pytest-cov dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 ddt==1.1.1
 mock==2.0.0
 pytest>=2.7
-pytest-cov
+pytest-cov<2.6.0
 pytest-mock==1.5.0


### PR DESCRIPTION
From https://github.com/pywbem/pywbem/issues/1371:

> Workaround is to pin the `pytest_cov` version to below 2.6.0.

Courtesy @markstur